### PR TITLE
Set utf8 encoding in xml encoder for request

### DIFF
--- a/src/XmlMiddleware.php
+++ b/src/XmlMiddleware.php
@@ -32,7 +32,7 @@ class XmlMiddleware
                     $data = $options[self::OPTION_XML];
                 }
 
-                $body = $encoder->encode($data, XmlEncoder::FORMAT);
+                $body = $encoder->encode($data, XmlEncoder::FORMAT, ['xml_encoding' => 'utf-8']);
                 unset($options[self::OPTION_XML]);
                 $request = $request->withHeader(self::HEADER_CONTENT_TYPE, self::MIME_TYPE_XML)
                     ->withBody(\GuzzleHttp\Psr7\stream_for($body));


### PR DESCRIPTION
Hi, I use guzzle-xml to transfer json to xml in request.
However, I find default xml encoding is not utf8 then I change default xml encoding.
Please merge it in master.

Thank you very much!